### PR TITLE
Fix index out of bounds in run_batches_parallel for single system run_if

### DIFF
--- a/src/world/run_batches.rs
+++ b/src/world/run_batches.rs
@@ -28,9 +28,7 @@ impl World {
 
                         true
                     } else {
-                        let run_if_index = batches.sequential_run_if[batch_run_if.0];
-
-                        match (batches.systems_run_if[run_if_index])(self) {
+                        match (batches.systems_run_if[batch_run_if.0])(self) {
                             Ok(should_run) => should_run,
                             Err(err) => {
                                 return Err(error::RunWorkload::Run((


### PR DESCRIPTION
## Summary
- `run_batches_parallel`에서 single system의 `run_if`를 처리할 때 `sequential_run_if`를 통한 불필요한 이중 간접참조가 있어 index out of bounds 패닉 발생
- `parallel_run_if.0`은 `systems_run_if`의 직접 인덱스인데, `sequential_run_if`의 인덱스로 잘못 사용됨
- `parallel_run_if.1` (병렬 시스템)은 이미 올바르게 직접 사용하고 있었음

## Related
- Upstream issue: https://github.com/leudz/shipyard/issues/233
- Introduced in: ee1837e ("Rewrite workload scheduler")

## Fix
`sequential_run_if` 간접참조를 제거하고 `batch_run_if.0`을 직접 `systems_run_if` 인덱스로 사용